### PR TITLE
Simplify join usage

### DIFF
--- a/salesforce_api/models/deploy.py
+++ b/salesforce_api/models/deploy.py
@@ -36,17 +36,17 @@ class Options(base.Model):
             self.__setattr__(key, kwargs[key])
 
     def as_xml(self):
-        return '\n'.join([
+        return '\n'.join(
             self._get_data_for_key(key, value)
             for key, value in vars(self).items()
-        ])
+        )
 
     def _get_data_for_key(self, key, value):
         if key == 'runTests':
-            return ''.join([
+            return ''.join(
                 f'<met:runTests>{test}</met:runTests>'
                 for test in value
-            ])
+            )
         return f'<met:{key}>{value}</met:{key}>'
 
 

--- a/salesforce_api/services/base.py
+++ b/salesforce_api/services/base.py
@@ -19,7 +19,8 @@ class _Service:
         return '/'.join(
             x.strip('/')
             for x in parts
-            if x is not None and x != ''
+            if x
+
         ).format(
             version=self.connection.version
         )

--- a/salesforce_api/services/base.py
+++ b/salesforce_api/services/base.py
@@ -15,14 +15,12 @@ class _Service:
         pass
 
     def _format_url(self, uri: str = None) -> str:
-        parts = [self.connection.instance_url, self.base_uri]
-        if uri is not None:
-            parts.append(uri)
-        return str('/'.join([
+        parts = [self.connection.instance_url, self.base_uri, uri]
+        return '/'.join(
             x.strip('/')
             for x in parts
             if x is not None and x != ''
-        ])).format(
+        ).format(
             version=self.connection.version
         )
 

--- a/salesforce_api/services/bulk/v1.py
+++ b/salesforce_api/services/bulk/v1.py
@@ -145,11 +145,11 @@ class Batch(base.AsyncService):
     def _convert_result(self, row):
         if row['success']:
             return models.SuccessResultRecord(row['id'], row)
-        error = ', '.join([
+        error = ', '.join(
             x['message']
             for x in row['errors']
-            if x['message'] != None
-        ])
+            if x['message'] is not None
+        )
         return models.FailResultRecord(row['id'], error, row)
 
     def wait(self) -> List[models.ResultRecord]:

--- a/salesforce_api/utils/bulk.py
+++ b/salesforce_api/utils/bulk.py
@@ -12,13 +12,12 @@ class FilePreparer:
         return len(self.entries) > 0
 
     def _check_headers(self) -> bool:
-        headers = [':'.join(x.keys()) for x in self.entries]
-        headers = list(set(headers))
+        headers = {tuple(x.keys()) for x in self.entries}
         return len(headers) == 1
 
     def _check_empty_rows(self) -> bool:
         for row in self.entries:
-            if ''.join(str(x) for x in row.values() if x is not None).strip() == '':
+            if all(x is None or str(x).strip() == '' for x in row.values()):
                 return False
         return True
 
@@ -38,7 +37,6 @@ class FilePreparer:
         writer.writerows([
             entry.values()
             for entry in self.entries
-            if ''.join([str(x) for x in entry.values() if x is not None]) != ''
         ])
         return file_handle
 


### PR DESCRIPTION
`join()` receives an iterable and can receive a generator expression as parameter, and always returns a str.

Also:

* set comprehension can be used to directly generate a set, instead of using list comprehension and then converting the list to a set.
* test if `is not None` instead of `!= None`.
* `all()` can be used to test all values of an iterable, instead of using `join()` to join all the values.
