### PR TITLE
Use f-string and pathlib.Path

### DIFF
--- a/salesforce_api/config.py
+++ b/salesforce_api/config.py
@@ -1,9 +1,8 @@
-import os.path
-
+from pathlib import Path
 
 RETRIEVE_SLEEP_SECONDS = 10
 DEPLOY_SLEEP_SECONDS = 20
 BULK_SLEEP_SECONDS = 5
-DATA_DIRECTORY = os.path.dirname(__file__) + '/data/'
+DATA_DIRECTORY = Path(__file__).parent / 'data'
 CLIENT_NAME = 'python-salesforce-api'
 BULK_VERSION = 2

--- a/salesforce_api/login.py
+++ b/salesforce_api/login.py
@@ -12,7 +12,7 @@ def magic(domain: str = None, username: str = None, password: str = None, securi
     # Determine address and instance url
     if domain is None:
         domain = 'test.salesforce.com' if is_sandbox else 'login.salesforce.com'
-    instance_url = 'https://' + domain
+    instance_url = f'https://{domain}'
 
     # Figure out how to authenticate
     if all([instance_url, username]) and (all([password, security_token]) or password_and_security_token):
@@ -59,7 +59,7 @@ def plain_access_token(instance_url: str, access_token: str, session: requests.S
 def oauth2(instance_url: str, client_id: str, client_secret: str, username: str, password: str,
            session: requests.Session = None, api_version: str = None) -> core.Connection:
     session = misc_utils.get_session(session)
-    response = session.post(instance_url + '/services/oauth2/token', data=dict(
+    response = session.post(f'{instance_url}/services/oauth2/token', data=dict(
         grant_type='password',
         client_id=client_id,
         client_secret=client_secret,
@@ -73,7 +73,7 @@ def oauth2(instance_url: str, client_id: str, client_secret: str, username: str,
     elif response_json.get('error') == 'invalid_client':
         raise exceptions.AuthenticationInvalidClientSecretError
     elif response.status_code != 200:
-        raise exceptions.AuthenticationError('Status-code ' + str(response.status_code) + ' returned while trying to authenticate')
+        raise exceptions.AuthenticationError(f'Status-code {response.status_code} returned while trying to authenticate')
 
     return plain_access_token(response_json['instance_url'], access_token=response_json['access_token'], session=session, api_version=api_version)
 
@@ -82,8 +82,7 @@ def soap(instance_url: str, username: str, password: str = None, security_token:
          password_and_security_token: str = None, session: requests.Session = None,
          api_version: str = None) -> core.Connection:
     session = misc_utils.get_session(session)
-    instance_url = instance_url + '/services/Soap/c/' + misc_utils.decide_version(api_version)
-    print(instance_url)
+    instance_url = f'{instance_url}/services/Soap/c/{misc_utils.decide_version(api_version)}'
 
     body = soap_utils.get_message('login/login.msg').format(
         username=username,

--- a/salesforce_api/models/base.py
+++ b/salesforce_api/models/base.py
@@ -5,5 +5,5 @@ class Model:
     def __repr__(self) -> str:
         return '<{name} {attributes} />'.format(
             name=self.__class__.__name__,
-            attributes=' '.join('{}="{}"'.format(k, v) for k, v in self.__dict__.items())
+            attributes=' '.join(f'{k}="{v}"' for k, v in self.__dict__.items())
         )

--- a/salesforce_api/models/deploy.py
+++ b/salesforce_api/models/deploy.py
@@ -31,7 +31,7 @@ class Options(base.Model):
             elif key == 'runTests' and not isinstance(kwargs[key], list):
                 raise Exception('Tests must be specified as a list')
             elif key not in specials and not isinstance(kwargs[key], bool):
-                raise Exception('Invalid option value for ' + key)
+                raise Exception(f'Invalid option value for {key}')
 
             self.__setattr__(key, kwargs[key])
 

--- a/salesforce_api/services/base.py
+++ b/salesforce_api/services/base.py
@@ -41,7 +41,7 @@ class RestService(_Service):
         self._setup_session()
 
     def _setup_session(self) -> None:
-        self.connection.session.headers['Authorization'] = 'Bearer ' + self.connection.access_token
+        self.connection.session.headers['Authorization'] = f'Bearer {self.connection.access_token}'
 
     def _request(self, verb: VERB, **kwargs):
         if 'headers' not in kwargs:

--- a/salesforce_api/services/basic.py
+++ b/salesforce_api/services/basic.py
@@ -1,5 +1,4 @@
 from . import base
-from ..const.service import VERB
 
 
 class Basic(base.RestService):
@@ -7,7 +6,7 @@ class Basic(base.RestService):
         super().__init__(connection, '')
 
     def versions(self) -> dict:
-        return self._request(VERB.GET, url=self.connection.instance_url + '/services/data')
+        return self._get_url(f'{self.connection.instance_url}/services/data')
 
     def resources(self) -> dict:
         return self._get()

--- a/salesforce_api/services/bulk/v1.py
+++ b/salesforce_api/services/bulk/v1.py
@@ -60,7 +60,7 @@ class Client(bulk_base.Client, base.AsyncService):
 
 class Job(base.AsyncService):
     def __init__(self, connection, job_id):
-        super().__init__(connection, 'job/' + job_id)
+        super().__init__(connection, f'job/{job_id}')
         self.job_id = job_id
         self.batches = []
 

--- a/salesforce_api/services/bulk/v2.py
+++ b/salesforce_api/services/bulk/v2.py
@@ -61,7 +61,7 @@ class Client(bulk_base.Client, base.RestService):
 
 class Job(base.RestService):
     def __init__(self, connection, job_id):
-        super().__init__(connection, 'jobs/ingest/' + job_id)
+        super().__init__(connection, f'jobs/ingest/{job_id}')
         self.job_id = job_id
 
     def _set_state(self, new_state: JOB_STATE):

--- a/salesforce_api/services/deploy.py
+++ b/salesforce_api/services/deploy.py
@@ -1,5 +1,7 @@
 import time
 from base64 import b64encode
+from pathlib import Path
+
 from .. import exceptions, const, config
 from ..utils import misc
 from ..models import deploy as models
@@ -9,10 +11,10 @@ from . import base
 class Deploy(base.SoapService):
     def _get_zip_content(self, input_file) -> str:
         if isinstance(input_file, str):
-            input_file = open(input_file, 'rb')
-        return b64encode(
-            input_file.read()
-        ).decode('utf-8')
+            s = Path(input_file).read_bytes()
+        else:
+            s = input_file.read()
+        return b64encode(s).decode()
 
     def deploy(self, input_zip, options: models.Options = models.Options()) -> 'Deployment':
         result = self._post(action='deploy', message_path='deploy/deploy.msg', message_attributes={

--- a/salesforce_api/services/retrieve.py
+++ b/salesforce_api/services/retrieve.py
@@ -53,8 +53,8 @@ class Retrieve(base.SoapService):
         for _type in types:
             output.append('<types>')
             for member in _type.members:
-                output.append('<members>' + member + '</members>')
-            output.append('<name>' + _type.name + '</name>')
+                output.append(f'<members>{member}</members>')
+            output.append(f'<name>{_type.name}</name>')
             output.append('</types>')
         return '\n'.join(output)
 

--- a/salesforce_api/services/sobjects.py
+++ b/salesforce_api/services/sobjects.py
@@ -5,16 +5,16 @@ from . import bulk
 
 class SObjects(base.RestService):
     def __init__(self, connection: core.Connection):
-        super().__init__(connection, 'sobjects')
+        super().__init__(connection)
 
     def describe(self):
-        return self._get()
+        return self._get('sobjects')
 
     def _query(self, query_string: str, include_deleted: bool = False):
-        return self._get('../queryAll' if include_deleted else '../query', {'q': query_string})
+        return self._get('queryAll' if include_deleted else 'query', {'q': query_string})
 
     def _query_more(self, next_url: str):
-        return self._get_url(self.connection.instance_url + next_url)
+        return self._get_url(f'{self.connection.instance_url}{next_url}')
 
     def query(self, query_string: str, include_deleted: bool = False):
         result = self._query(query_string, include_deleted)
@@ -30,7 +30,7 @@ class SObjects(base.RestService):
 
 class SObject(base.RestService):
     def __init__(self, connection: core.Connection, object_name: str):
-        super().__init__(connection, 'sobjects/' + object_name)
+        super().__init__(connection, f'sobjects/{object_name}')
         self.bulk = bulk.BulkObject(object_name, connection)
 
     def metadata(self):
@@ -46,7 +46,7 @@ class SObject(base.RestService):
         return self._post(json=data)
 
     def upsert(self, external_id_field: str, external_id_value: str, data: dict):
-        self._patch(external_id_field + '/' + external_id_value, json=data)
+        self._patch(f'{external_id_field}/{external_id_value}', json=data)
         return True
 
     def update(self, record_id: str, data: dict):

--- a/salesforce_api/services/tooling.py
+++ b/salesforce_api/services/tooling.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from .. import core
 from ..models import tooling as tooling_models
 from . import base
@@ -17,8 +19,7 @@ class Tooling(base.RestService):
         )
 
     def execute_apex_from_file(self, file_path: str):
-        with open(file_path, 'r') as fh:
-            return self.execute_apex(fh.read())
+        return self.execute_apex(Path(file_path).read_text())
 
     def query(self, query: str):
         return self._get('query', {'q': query})
@@ -41,7 +42,7 @@ class Tooling(base.RestService):
 
 class ToolingObject(base.RestService):
     def __init__(self, object_name: str, connection: core.Connection):
-        super().__init__(connection, 'tooling/sobjects/' + object_name)
+        super().__init__(connection, f'tooling/sobjects/{object_name}')
 
     def describe(self):
         return self._get('describe')

--- a/salesforce_api/utils/soap.py
+++ b/salesforce_api/utils/soap.py
@@ -4,7 +4,8 @@ from .. import exceptions, config
 
 
 def get_message(path: str) -> str:
-    return open(config.DATA_DIRECTORY + 'soap_messages/' + path).read()
+    return (config.DATA_DIRECTORY / 'soap_messages' / path).read_text()
+
 
 def parse_path(path: str) -> list:
     return path.split('/')

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
-import os
-from glob import glob
+from pathlib import Path
+
 from setuptools import setup, find_packages
 
 
 def data_files_inventory():
-    data_files = []
     data_roots = ['salesforce_api/data']
-    for data_root in data_roots:
-        for root, subfolder, files in os.walk(data_root):
-            files = [x.replace('salesforce_api/', '') for x in glob(root + '/*')
-                     if not os.path.isdir(x)]
-            data_files = data_files + files
-    return data_files
+    return [
+        str(x.relative_to('salesforce_api'))
+        for data_root in data_roots
+        for x in Path(data_root).glob('**/*')
+        if not x.is_dir()
+    ]
 
 
 PACKAGE_DATA = {'salesforce_api': data_files_inventory()}
@@ -25,7 +24,7 @@ if __name__ == '__main__':
         author="Felix Lindstrom",
         author_email='felix.lindstrom@gmail.com',
         description="Salesforce API wrapper",
-        long_description=open('README.md').read(),
+        long_description=Path('README.md').read_text(),
         long_description_content_type="text/markdown",
         keywords=['salesforce', 'salesforce api', 'salesforce bulk api'],
         license='MIT',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
 import time
-import os
 import json
+from pathlib import Path
 from string import Template
 from salesforce_api import Salesforce, const
 from salesforce_api.const.service import VERB
@@ -10,7 +10,7 @@ TEST_CLIENT_SECRET = 'test-secret'
 TEST_SECURITY_TOKEN = 'test-token'
 TEST_ACCESS_TOKEN = 'test-access-token'
 TEST_DOMAIN = 'example.cs108.my.salesforce.com'
-TEST_INSTANCE_URL = 'https://' + TEST_DOMAIN
+TEST_INSTANCE_URL = f'https://{TEST_DOMAIN}'
 TEST_ISSUE_TIME = time.time()
 TEST_ID = 'https://test.salesforce.com/id/123/456'
 TEST_SIGNATURE = '123456789'
@@ -22,8 +22,8 @@ TEST_ROLE_ID = '123'
 TEST_PROFILE_ID = '123'
 TEST_ORG_NAME = 'Test Org'
 TEST_ORG_ID = '123'
-TEST_SERVER_URL = TEST_INSTANCE_URL + '/services/Soap/c/44.0/123'
-TEST_METADATA_URL = TEST_INSTANCE_URL + '/services/Soap/m/44.0/123'
+TEST_SERVER_URL = f'{TEST_INSTANCE_URL}/services/Soap/c/44.0/123'
+TEST_METADATA_URL = f'{TEST_INSTANCE_URL}/services/Soap/m/44.0/123'
 TEST_OBJECT_NAME = 'Contact'
 TEST_BULK_OPERATION = 'insert'
 
@@ -48,7 +48,7 @@ def get_data(path, sub_overrides={}):
         'operation': TEST_BULK_OPERATION,
         'version': const.API_VERSION
     }, **sub_overrides}
-    return Template(open(os.path.dirname(__file__) + '/data/' + path, 'r').read()).substitute(substitutes)
+    return Template((Path(__file__).parent / 'data' / path).read_text()).substitute(substitutes)
 
 
 class BaseTest:

--- a/tests/test_service_bulk_v1.py
+++ b/tests/test_service_bulk_v1.py
@@ -18,25 +18,25 @@ class TestServiceBulk(helpers.BaseTest):
             'id': _JOB_ID
         })
 
-        self.register_uri(requests_mock, VERB.POST, _BASE_URL + '/' + _JOB_ID, json={
+        self.register_uri(requests_mock, VERB.POST, f'{_BASE_URL}/{_JOB_ID}', json={
             'id': _JOB_ID
         })
 
-        self.register_uri(requests_mock, VERB.GET, _BASE_URL + '/' + _JOB_ID, json={
+        self.register_uri(requests_mock, VERB.GET, f'{_BASE_URL}/{_JOB_ID}', json={
             'id': _JOB_ID,
             'state': JOB_STATE.CLOSED.value
         })
 
-        self.register_uri(requests_mock, VERB.POST, _BASE_URL + '/' + _JOB_ID + '/batch', json={
+        self.register_uri(requests_mock, VERB.POST, f'{_BASE_URL}/{_JOB_ID}/batch', json={
             'id': _BATCH_ID
         })
 
-        self.register_uri(requests_mock, VERB.GET, _BASE_URL + '/' + _JOB_ID + '/batch/' + _BATCH_ID, json={
+        self.register_uri(requests_mock, VERB.GET, f'{_BASE_URL}/{_JOB_ID}/batch/{_BATCH_ID}', json={
             'id': _BATCH_ID,
             'state': BATCH_STATE.COMPLETED.value
         })
 
-        self.register_uri(requests_mock, VERB.GET, _BASE_URL + '/' + _JOB_ID + '/batch/' + _BATCH_ID + '/result', text=helpers.get_data('bulk/v1/success_result.txt'))
+        self.register_uri(requests_mock, VERB.GET, f'{_BASE_URL}/{_JOB_ID}/batch/{_BATCH_ID}/result', text=helpers.get_data('bulk/v1/success_result.txt'))
 
     def create_contact(self, first_name, last_name):
         return {

--- a/tests/test_service_bulk_v2.py
+++ b/tests/test_service_bulk_v2.py
@@ -13,12 +13,12 @@ class TestServiceBulk(helpers.BaseTest):
     def setup_instance(self, requests_mock):
         self.register_uri(requests_mock, VERB.POST, _BASE_URL, text=helpers.get_data('bulk/v2/create.txt'))
 
-        self.register_uri(requests_mock, VERB.GET, _BASE_URL + '/' + _JOB_ID, text=helpers.get_data('bulk/v2/info.txt'))
-        self.register_uri(requests_mock, VERB.PATCH, _BASE_URL + '/' + _JOB_ID, text=helpers.get_data('bulk/v2/upload_complete.txt'))
-        self.register_uri(requests_mock, VERB.PUT, _BASE_URL + '/' + _JOB_ID + '/batches', text='')
+        self.register_uri(requests_mock, VERB.GET, f'{_BASE_URL}/{_JOB_ID}', text=helpers.get_data('bulk/v2/info.txt'))
+        self.register_uri(requests_mock, VERB.PATCH, f'{_BASE_URL}/{_JOB_ID}', text=helpers.get_data('bulk/v2/upload_complete.txt'))
+        self.register_uri(requests_mock, VERB.PUT, f'{_BASE_URL}/{_JOB_ID}/batches', text='')
 
-        self.register_uri(requests_mock, VERB.GET, _BASE_URL + '/' + _JOB_ID + '/successfulResults', text=helpers.get_data('bulk/v2/successful_results.txt'))
-        self.register_uri(requests_mock, VERB.GET, _BASE_URL + '/' + _JOB_ID + '/failedResults', text=helpers.get_data('bulk/v2/failed_results.txt'))
+        self.register_uri(requests_mock, VERB.GET, f'{_BASE_URL}/{_JOB_ID}/successfulResults', text=helpers.get_data('bulk/v2/successful_results.txt'))
+        self.register_uri(requests_mock, VERB.GET, f'{_BASE_URL}/{_JOB_ID}/failedResults', text=helpers.get_data('bulk/v2/failed_results.txt'))
 
 
     def create_contact(self, first_name, last_name):

--- a/tests/test_service_sobjects.py
+++ b/tests/test_service_sobjects.py
@@ -24,7 +24,7 @@ class TestServiceSObject(helpers.BaseTest):
         return self.get_service('sobjects').__getattr__(_TEST_OBJECT)
 
     def _get_url(self, additional=None):
-        return '/services/data/v{version}/sobjects/' + _TEST_OBJECT + ('/' + additional if additional else '')
+        return '/services/data/v{version}/sobjects/' + _TEST_OBJECT + (f'/{additional}' if additional else '')
 
     def test_metadata(self, requests_mock):
         self.register_uri(requests_mock, VERB.GET, self._get_url(), text='{}')


### PR DESCRIPTION
since minimal supported version is already Python 3.6. See https://docs.python.org/3.6/reference/lexical_analysis.html#formatted-string-literals and https://docs.python.org/3.6/library/pathlib.html#pathlib.Path.read_bytes

The use of open without a context manager ("with open()") or without a respective close can potentially leave file descriptors open.

Also default encoding in bytes.decode is already 'utf-8'. See https://docs.python.org/3.6/library/stdtypes.html#bytes.decode
