### PR TITLE
fix: remove distutils dependency

### DIFF
--- a/salesforce_api/utils/misc.py
+++ b/salesforce_api/utils/misc.py
@@ -1,4 +1,3 @@
-import distutils.util
 import hashlib
 from typing import Union
 
@@ -8,7 +7,7 @@ from ..const import API_VERSION
 
 
 def parse_bool(input_value: str) -> bool:
-    return distutils.util.strtobool(input_value)
+    return bool(input_value)
 
 
 def get_session(session: Union[requests.Session, None] = None):


### PR DESCRIPTION
It makes the code compatible with Python 3.12, as `distutils` [was deprecated and removed](https://docs.python.org/3.10/library/distutils.html#module-distutils).